### PR TITLE
Add basic UNIQLO price tracker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+price_data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # CODEX UNIQLO Tracker
+
+該範例提供一個簡易的 `uniqlo_tracker.py` 腳本，可模擬追蹤 UNIQLO 商品價格。首次執行時會將內建的 base64 編碼商品清單解碼至 `price_data/products.csv`，隨後每次執行都會更新價格。
+
+## 執行方式
+
+```bash
+python3 uniqlo_tracker.py
+```
+
+腳本會印出商品目前價格，如價格低於上次紀錄，則顯示降價訊息，同時會把新價格寫回 `price_data/products.csv`。

--- a/uniqlo_tracker.py
+++ b/uniqlo_tracker.py
@@ -1,0 +1,59 @@
+import os
+import csv
+import base64
+import random
+
+DATA_DIR = 'price_data'
+SAMPLE_CSV_B64 = (
+    "cHJvZHVjdF9pZCxwcm9kdWN0X25hbWUscHJpY2UKMTIzLFVuaXFsbyBULVNoaXJ0LDE5Ljk5Cj"
+    "Q1NixVbmlxbG8gSmVhbnMsMzkuOTkK"
+)
+
+
+def ensure_sample_csv():
+    os.makedirs(DATA_DIR, exist_ok=True)
+    csv_path = os.path.join(DATA_DIR, 'products.csv')
+    if not os.path.exists(csv_path):
+        data = base64.b64decode(SAMPLE_CSV_B64)
+        with open(csv_path, 'wb') as f:
+            f.write(data)
+    return csv_path
+
+
+def load_products(csv_path):
+    with open(csv_path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def fetch_current_price(product_id):
+    # TODO: Replace with real fetching from UNIQLO site
+    return round(random.uniform(10, 50), 2)
+
+
+def save_products(csv_path, products):
+    fieldnames = ['product_id', 'product_name', 'price']
+    with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(products)
+
+
+def main():
+    csv_path = ensure_sample_csv()
+    products = load_products(csv_path)
+
+    for product in products:
+        current_price = fetch_current_price(product['product_id'])
+        last_price = float(product['price'])
+        if current_price < last_price:
+            print(f"{product['product_name']} 降價 {last_price} -> {current_price}")
+        else:
+            print(f"{product['product_name']} 目前價格 {current_price}")
+        product['price'] = str(current_price)
+
+    save_products(csv_path, products)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add example tracker script `uniqlo_tracker.py`
- update README with running instructions
- ignore generated price_data directory

## Testing
- `python3 uniqlo_tracker.py`

------
https://chatgpt.com/codex/tasks/task_e_68465ae5ff5083209800c42dd6ee9deb